### PR TITLE
Allow Symfony versions > 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony": "2.4.*",
+        "symfony/symfony": ">=2.4",
         "codeconsortium/ccdn-component-bb-code": "dev-master"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony": ">=2.4",
+        "symfony/symfony": "~2.4",
         "codeconsortium/ccdn-component-bb-code": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Seems to work fine with 2.5+, is there any specific reason to limit it to 2.4?
